### PR TITLE
Bring homepage up to the latest mha-redesign: category filter + load …

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -332,6 +332,11 @@ html[data-theme="dark"] .theme-toggle .moon { display: block; }
 
 .hero h1 .alt { color: var(--green); }
 
+.hero h1 .word {
+  display: inline-block;
+  clip-path: inset(0 0 0 0);
+}
+
 .hero p.tagline {
   font-size: 18px;
   max-width: 44ch;
@@ -510,11 +515,28 @@ html[data-theme="dark"] .hero-art img {
 
 .post-row:hover .post-title { background-size: 100% 3px; }
 
+.post-row .excerpt {
+  display: block;
+  margin-top: 7px;
+  font-size: 14.5px;
+  line-height: 1.65;
+  color: var(--muted);
+  max-width: 58ch;
+}
+
 .post-row .post-meta {
   display: flex;
   gap: 8px;
-  margin-top: 4px;
+  margin-top: 10px;
   flex-wrap: wrap;
+  align-items: center;
+}
+
+.post-row .read-time {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--faint);
+  letter-spacing: 0.04em;
 }
 
 .tag {
@@ -539,6 +561,191 @@ html[data-theme="dark"] .hero-art img {
   font-size: 12.5px;
   color: var(--faint);
   white-space: nowrap;
+}
+
+/* ---------- filter bar ---------- */
+.filter-bar {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 16px 0;
+  margin-bottom: 10px;
+  background: var(--bg);
+  border-bottom: 2px solid var(--line-strong);
+  transition: background-color 0.35s ease;
+}
+
+.filter-bar .result-count {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  color: var(--faint);
+  margin-left: auto;
+}
+
+.filter-bar .result-count b { color: var(--green); font-weight: 600; }
+
+.dropdown { position: relative; }
+
+.dd-trigger {
+  appearance: none;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-width: 236px;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--ink);
+  background: var(--surface);
+  border: 2px solid var(--line-strong);
+  padding: 10px 14px;
+  box-shadow: var(--shadow-pop-sm);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.35s ease;
+}
+
+.dd-trigger:hover { transform: translate(-2px, -2px); box-shadow: 6px 6px 0 var(--accent); }
+
+.dd-trigger .dd-label {
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  color: var(--faint);
+  border-right: 2px solid var(--line);
+  padding-right: 12px;
+}
+
+.dd-trigger .dd-value { flex: 1; text-align: left; text-transform: uppercase; }
+
+.dd-trigger .dd-caret {
+  font-size: 10px;
+  color: var(--accent-deep);
+  transition: transform 0.24s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.dropdown.open .dd-trigger { transform: translate(-2px, -2px); box-shadow: 6px 6px 0 var(--accent); }
+.dropdown.open .dd-caret { transform: rotate(180deg); }
+
+.dd-menu {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 0;
+  min-width: 268px;
+  background: var(--surface);
+  border: 2px solid var(--line-strong);
+  box-shadow: 7px 7px 0 var(--accent);
+  padding: 6px;
+  z-index: 40;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-8px) scaleY(0.96);
+  transform-origin: top;
+  transition: opacity 0.2s ease, transform 0.24s cubic-bezier(0.2, 0.8, 0.2, 1), visibility 0.24s;
+}
+
+.dropdown.open .dd-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0) scaleY(1);
+}
+
+.dd-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  cursor: pointer;
+  text-align: left;
+  appearance: none;
+  background: none;
+  border: none;
+  border-left: 4px solid transparent;
+  padding: 10px 12px;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  transition: background-color 0.16s ease, color 0.16s ease, border-color 0.16s ease;
+}
+
+.dropdown.open .dd-item {
+  animation: dd-in 0.26s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.dropdown.open .dd-item:nth-child(1) { animation-delay: 0.02s; }
+.dropdown.open .dd-item:nth-child(2) { animation-delay: 0.05s; }
+.dropdown.open .dd-item:nth-child(3) { animation-delay: 0.08s; }
+.dropdown.open .dd-item:nth-child(4) { animation-delay: 0.11s; }
+.dropdown.open .dd-item:nth-child(5) { animation-delay: 0.14s; }
+
+@keyframes dd-in {
+  from { opacity: 0; transform: translateX(-10px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+.dd-item:hover { background: var(--bg); color: var(--ink); border-left-color: var(--accent); }
+
+.dd-item[aria-selected="true"] {
+  color: var(--ink);
+  border-left-color: var(--green);
+  background: var(--bg);
+}
+
+.dd-item .dd-name { flex: 1; text-transform: uppercase; }
+
+.dd-item .dd-count {
+  font-size: 11px;
+  color: var(--bg);
+  background: var(--faint);
+  padding: 1px 7px;
+  transition: background-color 0.16s ease;
+}
+
+.dd-item[aria-selected="true"] .dd-count { background: var(--green); }
+.dd-item:hover .dd-count { background: var(--accent-deep); }
+
+.dd-item[data-empty="true"] { opacity: 0.45; }
+
+/* filtering motion */
+.post-row-wrap {
+  overflow: hidden;
+  transition: opacity 0.28s ease, transform 0.28s ease;
+}
+
+.post-row-wrap[hidden] { display: none; }
+
+.post-row-wrap.filtering-in {
+  animation: row-in 0.34s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+@keyframes row-in {
+  from { opacity: 0; transform: translateX(-14px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+/* deep-link arrival flash */
+.filter-bar.just-filtered .dd-trigger {
+  animation: dd-flash 1.3s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+@keyframes dd-flash {
+  0%   { box-shadow: 0 0 0 0 var(--accent); transform: translate(0, 0); }
+  18%  { box-shadow: 10px 10px 0 var(--accent); transform: translate(-4px, -4px); }
+  100% { box-shadow: var(--shadow-pop-sm); transform: translate(0, 0); }
+}
+
+.empty-state {
+  padding: 56px 0;
+  text-align: center;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  color: var(--faint);
 }
 
 /* ---------- section cards ---------- */
@@ -1086,6 +1293,71 @@ html[data-theme="dark"] .hero-art img {
   .reveal.d4 { transition-delay: 0.28s; }
 }
 
+/* ---------- homepage load motion ---------- */
+@media (prefers-reduced-motion: no-preference) {
+  html.is-loaded .hero-tex .speedlines { animation: sweep-lines 1.1s cubic-bezier(0.16, 0.9, 0.2, 1) both; }
+  html.is-loaded .hero-tex .halftone { animation: dots-in 1.3s cubic-bezier(0.16, 0.9, 0.2, 1) both; }
+  html.is-loaded .hero-art .ring { animation: ring-in 0.9s cubic-bezier(0.2, 0.8, 0.2, 1) both, ring-spin 34s linear 1s infinite; }
+  html.is-loaded .hero-art .burst { animation: burst-in 0.7s cubic-bezier(0.2, 0.9, 0.2, 1) 0.1s both, burst-pulse 5.5s ease-in-out 1.2s infinite; }
+  html.is-loaded .hero-art img { animation: logo-smash 0.75s cubic-bezier(0.18, 1.1, 0.3, 1) 0.15s both; }
+  html.is-loaded .hero h1 .word { animation: word-rise 0.72s cubic-bezier(0.16, 1, 0.3, 1) both; }
+  html.is-loaded .hero h1 .word:nth-child(1) { animation-delay: 0.16s; }
+  html.is-loaded .hero h1 .word:nth-child(2) { animation-delay: 0.26s; }
+  html.is-loaded .top-stripe { animation: stripe-wipe 0.8s cubic-bezier(0.16, 0.9, 0.2, 1) both; }
+}
+
+@keyframes stripe-wipe {
+  from { clip-path: inset(0 100% 0 0); }
+  to   { clip-path: inset(0 0 0 0); }
+}
+
+@keyframes sweep-lines {
+  from { opacity: 0; transform: translateX(-70px) skewX(-6deg); }
+  to   { opacity: var(--tex-opacity, 1); transform: none; }
+}
+
+@keyframes dots-in {
+  from { opacity: 0; transform: scale(1.15); }
+  to   { opacity: var(--tex-opacity, 1); transform: none; }
+}
+
+@keyframes word-rise {
+  from { opacity: 0; transform: translateY(0.5em) rotate(1.5deg); clip-path: inset(0 0 100% 0); }
+  to   { opacity: 1; transform: none; clip-path: inset(-30% -30% -30% -30%); }
+}
+
+@keyframes logo-smash {
+  0%   { opacity: 0; transform: scale(0.72) rotate(-7deg); }
+  70%  { opacity: 1; transform: scale(1.05) rotate(1.5deg); }
+  100% { opacity: 1; transform: scale(1) rotate(0); }
+}
+
+@keyframes burst-in {
+  from { opacity: 0; transform: translate(-50%, -50%) scale(0.3); }
+  to   { opacity: 0.22; transform: translate(-50%, -50%) scale(1); }
+}
+
+@keyframes burst-pulse {
+  0%, 100% { opacity: 0.18; transform: translate(-50%, -50%) scale(1); }
+  50%      { opacity: 0.3;  transform: translate(-50%, -50%) scale(1.06); }
+}
+
+@keyframes ring-in {
+  from { opacity: 0; transform: translate(-50%, -50%) scale(0.6) rotate(-40deg); }
+  to   { opacity: 0.45; transform: translate(-50%, -50%) scale(1) rotate(0); }
+}
+
+@keyframes ring-spin {
+  from { transform: translate(-50%, -50%) rotate(0); }
+  to   { transform: translate(-50%, -50%) rotate(360deg); }
+}
+
+/* ---------- scroll reveal (section cards) ---------- */
+@media (prefers-reduced-motion: no-preference) {
+  .sr { opacity: 0; transform: translateY(20px); transition: opacity 0.6s cubic-bezier(0.2, 0.7, 0.2, 1), transform 0.6s cubic-bezier(0.2, 0.7, 0.2, 1); }
+  .sr.shown { opacity: 1; transform: none; }
+}
+
 /* ---------- responsive ---------- */
 @media (max-width: 900px) {
   .hero .wrap { grid-template-columns: 1fr; padding-top: 44px; padding-bottom: 44px; }
@@ -1103,6 +1375,9 @@ html[data-theme="dark"] .hero-art img {
   .site-nav { display: none; }
   .nav-mobile { display: block; }
   .header-right { gap: 10px; }
+  .filter-bar { position: static; }
+  .dd-trigger { min-width: 0; width: 100%; }
+  .filter-bar .result-count { margin-left: 0; }
 }
 
 /* ---------- search dialog & pagefind UI theming ---------- */

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,7 +7,7 @@
     <div class="wrap">
       <div class="hero-copy">
         <p class="hero-kicker reveal">PERSONAL BLOG — GO BEYOND</p>
-        <h1 class="reveal d1">Kid<span class="alt">peterpan</span></h1>
+        <h1 class="reveal d1"><span class="word">Kid</span><span class="word alt">peterpan</span></h1>
         <p class="tagline reveal d2">Notes on books, code, and everything I'm learning along the way — one step past my limits at a time.</p>
         <div class="hero-links reveal d3">
           {{ with site.Sections }}
@@ -31,19 +31,38 @@
     {{ with site.RegularPages.ByDate.Reverse }}
       <section class="reveal d2">
         <div class="section-head">
-          <h2>Latest</h2>
+          <h2>All notes</h2>
           <div class="rule"></div>
-          <span class="count">{{ len . }} POST{{ if ne (len .) 1 }}S{{ end }}</span>
         </div>
+
+        <div class="filter-bar">
+          <div class="dropdown">
+            <button class="dd-trigger" type="button" aria-haspopup="listbox" aria-expanded="false">
+              <span class="dd-label">CATEGORY</span>
+              <span class="dd-value">All</span>
+              <span class="dd-caret">▼</span>
+            </button>
+            <div class="dd-menu" role="listbox">
+              <button class="dd-item" type="button" role="option" data-cat="all" aria-selected="true"><span class="dd-name">All</span><span class="dd-count">{{ len . }}</span></button>
+              {{ range site.Sections }}
+                <button class="dd-item" type="button" role="option" data-cat="{{ .Section }}" aria-selected="false"{{ if eq (len .RegularPages) 0 }} data-empty="true"{{ end }}><span class="dd-name">{{ .Title }}</span><span class="dd-count">{{ len .RegularPages }}</span></button>
+              {{ end }}
+            </div>
+          </div>
+          <p class="result-count">SHOWING <b>{{ len . }}</b> NOTES</p>
+        </div>
+
         <ul class="post-list">
           {{ range $i, $p := . }}
-            <li>
+            <li class="post-row-wrap" data-cat="{{ $p.Section }}">
               <a class="post-row" href="{{ $p.RelPermalink }}">
                 <span class="idx">{{ printf "%02d" (add $i 1) }}</span>
                 <span class="title-group">
                   <span class="post-title">{{ $p.Title }}</span>
+                  {{ with $p.Description }}<span class="excerpt">{{ . }}</span>{{ end }}
                   <span class="post-meta">
                     <span class="tag">{{ $p.Section }}</span>
+                    <span class="read-time">{{ $p.ReadingTime }} MIN</span>
                   </span>
                 </span>
                 {{ if not $p.Date.IsZero }}
@@ -53,6 +72,7 @@
             </li>
           {{ end }}
         </ul>
+        <p class="empty-state" hidden>NO NOTES IN THIS CATEGORY YET.</p>
       </section>
     {{ end }}
 
@@ -64,7 +84,7 @@
         </div>
         <div class="section-cards">
           {{ range $i, $s := . }}
-            <a class="section-card" href="{{ $s.RelPermalink }}">
+            <a class="section-card sr" href="{{ $s.RelPermalink }}">
               <div class="card-tex {{ cond (eq (mod $i 2) 0) "halftone" "speedlines" }}"></div>
               <h3>{{ $s.Title }}</h3>
               <p>{{ $s.Description }}</p>
@@ -79,4 +99,6 @@
     {{ end }}
 
   </main>
+
+  <script src="{{ "/js/filter.js" | relURL }}"></script>
 {{ end }}

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -1,0 +1,122 @@
+// Homepage behaviour: category dropdown + filter, section-card scroll reveal.
+(function () {
+  var reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  /* ---------- category dropdown + filter ---------- */
+  function initFilter() {
+    var dd = document.querySelector('.dropdown');
+    if (!dd) return;
+    var trigger = dd.querySelector('.dd-trigger');
+    var valueEl = dd.querySelector('.dd-value');
+    var items = Array.prototype.slice.call(dd.querySelectorAll('.dd-item'));
+    var rows = Array.prototype.slice.call(document.querySelectorAll('.post-row-wrap'));
+    var countEl = document.querySelector('.result-count b');
+    var emptyEl = document.querySelector('.empty-state');
+
+    function close() {
+      dd.classList.remove('open');
+      trigger.setAttribute('aria-expanded', 'false');
+    }
+    function toggle() {
+      var open = dd.classList.toggle('open');
+      trigger.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+
+    function apply(cat) {
+      var shown = 0;
+      rows.forEach(function (row) {
+        var match = cat === 'all' || row.dataset.cat === cat;
+        row.hidden = !match;
+        row.classList.remove('filtering-in');
+        if (match) {
+          shown++;
+          var idx = row.querySelector('.idx');
+          if (idx) idx.textContent = String(shown).padStart(2, '0');
+          if (!reduced) {
+            // restart the entry animation
+            void row.offsetWidth;
+            row.style.animationDelay = Math.min(shown, 8) * 0.035 + 's';
+            row.classList.add('filtering-in');
+          }
+        }
+      });
+      if (countEl) countEl.textContent = shown;
+      if (emptyEl) emptyEl.hidden = shown !== 0;
+      items.forEach(function (it) {
+        it.setAttribute('aria-selected', it.dataset.cat === cat ? 'true' : 'false');
+      });
+      if (valueEl) {
+        var active = items.filter(function (i) { return i.dataset.cat === cat; })[0];
+        valueEl.textContent = active ? active.querySelector('.dd-name').textContent : 'All';
+      }
+      try { history.replaceState(null, '', cat === 'all' ? location.pathname : '?cat=' + cat); } catch (e) {}
+    }
+
+    trigger.addEventListener('click', function (e) { e.stopPropagation(); toggle(); });
+
+    items.forEach(function (it) {
+      it.addEventListener('click', function () {
+        apply(it.dataset.cat);
+        close();
+      });
+    });
+
+    document.addEventListener('click', function (e) {
+      if (!dd.contains(e.target)) close();
+    });
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') close();
+    });
+
+    var initial = 'all';
+    var fromUrl = false;
+    try {
+      var q = new URLSearchParams(location.search).get('cat');
+      if (q && items.some(function (i) { return i.dataset.cat === q; })) { initial = q; fromUrl = true; }
+    } catch (e) {}
+    apply(initial);
+
+    // Landing on a deep link (?cat=go) applies the filter far below the fold —
+    // bring the list into view so the nav link visibly does something.
+    if (fromUrl) {
+      var bar = document.querySelector('.filter-bar');
+      if (bar) {
+        var target = Math.max(0, bar.offsetTop - 16);
+        var jump = function () {
+          window.scrollTo({ top: target, behavior: 'auto' });
+          if (document.scrollingElement) document.scrollingElement.scrollTop = target;
+        };
+        requestAnimationFrame(jump);
+        window.addEventListener('load', jump, { once: true });
+        // Visible confirmation that the nav link did something, even if the
+        // jump is suppressed (some embedded viewers block programmatic scroll).
+        bar.classList.add('just-filtered');
+        setTimeout(function () { bar.classList.remove('just-filtered'); }, 1400);
+      }
+    }
+  }
+
+  /* ---------- scroll reveal ---------- */
+  function initReveal() {
+    var els = document.querySelectorAll('.sr');
+    if (!els.length) return;
+    if (reduced || !('IntersectionObserver' in window)) {
+      els.forEach(function (el) { el.classList.add('shown'); });
+      return;
+    }
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('shown');
+          io.unobserve(entry.target);
+        }
+      });
+    }, { rootMargin: '0px 0px -8% 0px', threshold: 0.05 });
+    els.forEach(function (el) { io.observe(el); });
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    initFilter();
+    initReveal();
+  });
+})();

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -12,6 +12,7 @@
   window.addEventListener('DOMContentLoaded', function () {
     setTimeout(function () {
       document.documentElement.classList.remove('anim-pre');
+      document.documentElement.classList.add('is-loaded');
     }, 60);
   });
 


### PR DESCRIPTION
…animations

The homepage was still on the base "hi-fi mockup" pass of the MHA redesign (design/mha-redesign as it stood before the filter-dropdown / animation / excerpt round). This ports that later round from the design bundle's mha-extras.css + mha.js into the real templates:

- All-notes list now shows every post (not just "Latest"), with a manga-styled category dropdown (sticky, animated, URL-persisted via ?cat=) built from site.Sections, plus per-post excerpt (from .Description) and read time (from .ReadingTime — the design mockup had hand-estimated these and called out Hugo computing them properly).
- Homepage load animations: top-stripe wipe, hero speed-lines sweep, halftone dots-in, word-by-word H1 rise, logo smash, ring spin/burst pulse — gated behind prefers-reduced-motion and an `is-loaded` class set by theme.js after first paint.
- Section cards now fade up on scroll via IntersectionObserver (.sr).

New static/js/filter.js carries the dropdown/filter and scroll-reveal logic (ported from design/mha-redesign/mha.js, trimmed to what the homepage uses — reading-progress and TOC scrollspy are single.html concerns, out of scope here).

Verified with `npm ci` + a full `hugo --minify` build and a dev-server pass in a browser (light/dark, dropdown open, category filtered, scroll-reveal).