### PR TITLE
Fix mobile: header overflow, to-top overlap, dropdown width mismatch

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -882,9 +882,13 @@ html[data-theme="dark"] .hero-art img {
   font-size: 17px;
   font-weight: 700;
   box-shadow: 3px 3px 0 rgba(15, 33, 27, 0.35);
-  transition: transform 0.15s ease;
+  transition: transform 0.15s ease, opacity 0.2s ease;
   z-index: 40;
+  opacity: 0;
+  pointer-events: none;
 }
+
+.to-top.is-visible { opacity: 1; pointer-events: auto; }
 
 .to-top:hover { transform: translateY(-3px); }
 
@@ -1374,10 +1378,22 @@ html[data-theme="dark"] .hero-art img {
   .post-row .idx { font-size: 20px; }
   .site-nav { display: none; }
   .nav-mobile { display: block; }
-  .header-right { gap: 10px; }
+  .header-right { gap: 8px; }
   .filter-bar { position: static; }
   .dd-trigger { min-width: 0; width: 100%; }
+  .dd-menu { width: 100%; min-width: 0; }
   .filter-bar .result-count { margin-left: 0; }
+}
+
+/* Header buttons (hamburger + search + theme + coffee) plus the brand
+   text don't all fit on one row below ~480px — trim the brand text and
+   drop the coffee button (least essential) rather than let it clip off
+   the edge of the viewport. */
+@media (max-width: 480px) {
+  .site-header .wrap { gap: 8px; }
+  .brand span { font-size: 12px; }
+  .brand-suffix { display: none; }
+  .coffee-btn { display: none; }
 }
 
 /* ---------- search dialog & pagefind UI theming ---------- */

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -36,7 +36,7 @@
     <header class="site-header">
       <div class="wrap">
         <a href="{{ "/" | relURL }}" class="brand">
-          <span>[<b>kidpeterpan</b>.github.io]</span>
+          <span>[<b>kidpeterpan</b><span class="brand-suffix">.github.io</span>]</span>
         </a>
         <div class="header-right">
           <nav class="site-nav">

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -23,4 +23,22 @@
       setTheme(currentTheme() === 'dark' ? 'light' : 'dark');
     });
   });
+
+  // Scroll-to-top button: stays hidden until scrolled past the hero, so it
+  // doesn't sit on top of the hero copy or the first post on small screens.
+  document.addEventListener('DOMContentLoaded', function () {
+    var toTop = document.querySelector('.to-top');
+    if (!toTop) return;
+    var ticking = false;
+    function update() {
+      toTop.classList.toggle('is-visible', window.scrollY > 480);
+      ticking = false;
+    }
+    update();
+    window.addEventListener('scroll', function () {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(update);
+    }, { passive: true });
+  });
 })();


### PR DESCRIPTION
Testing the new homepage at real phone widths (320-390px) surfaced three concrete bugs, not just general roughness:

- Header overflow: brand text + hamburger + search + theme-toggle + coffee button don't fit one unwrapping flex row below ~480px, so the coffee button (and on 320px phones, the theme toggle too) was clipped off the right edge of the viewport, completely inaccessible. Wraps the ".github.io" suffix in a span so it can drop out under 480px, and hides the coffee button at that width (least essential of the four).
- to-top button had no scroll-based visibility toggle, so it sat fixed bottom-right at all times — on load this covered the hero tagline, and while scrolling it covered post-row content. Now hidden until scrollY > 480 (theme.js), with a matching CSS opacity/pointer-events gate.
- .dd-menu (category dropdown) kept its desktop min-width instead of matching .dd-trigger's mobile full-width, so the open menu looked narrower than and misaligned with the button that opened it.

Verified at 320px and 375px viewports with a real dev-server build.